### PR TITLE
Add gesture coordination options: edge activation mode, activation distance, indicator management

### DIFF
--- a/Development/Development/ContentView.swift
+++ b/Development/Development/ContentView.swift
@@ -128,7 +128,9 @@ struct SwiftUIDiagnosticDemo: View {
         configuration: .init(
           ignoresScrollView: config.ignoresScrollView,
           targetEdges: config.targetEdges,
-          sticksToEdges: config.sticksToEdges
+          sticksToEdges: config.sticksToEdges,
+          edgeActivationMode: config.edgeActivationMode,
+          minimumActivationDistance: config.minimumActivationDistance
         ),
         isScrollLockEnabled: $config.isScrollLockEnabled,
         coordinateSpaceInDragging: .global,

--- a/Development/Development/DiagnosticOverlay.swift
+++ b/Development/Development/DiagnosticOverlay.swift
@@ -31,13 +31,37 @@ enum TargetEdgesOption: String, CaseIterable, Identifiable {
   }
 }
 
+enum EdgeActivationModeOption: String, CaseIterable, Identifiable {
+  case anytime
+  case onlyAtGestureStart
+
+  var id: String { rawValue }
+
+  var mode: EdgeActivationMode {
+    switch self {
+    case .anytime: return .anytime
+    case .onlyAtGestureStart: return .onlyAtGestureStart
+    }
+  }
+
+  var label: String {
+    switch self {
+    case .anytime: return ".anytime"
+    case .onlyAtGestureStart: return ".onlyAtGestureStart"
+    }
+  }
+}
+
 struct DemoConfig: Equatable {
   var sticksToEdges: Bool = true
   var ignoresScrollView: Bool = false
   var targetEdgesOption: TargetEdgesOption = .all
   var isScrollLockEnabled: Bool = false
+  var edgeActivationModeOption: EdgeActivationModeOption = .anytime
+  var minimumActivationDistance: CGFloat = 0
 
   var targetEdges: ScrollViewEdge { targetEdgesOption.scrollViewEdge }
+  var edgeActivationMode: EdgeActivationMode { edgeActivationModeOption.mode }
 }
 
 struct ScrollState: Equatable {
@@ -74,6 +98,31 @@ struct ConfigPanel: View {
           }
         }
         .pickerStyle(.menu)
+        .labelsHidden()
+      }
+      HStack {
+        Text("edgeActivationMode")
+        Spacer()
+        Picker("", selection: $config.edgeActivationModeOption) {
+          ForEach(EdgeActivationModeOption.allCases) { option in
+            Text(option.label).tag(option)
+          }
+        }
+        .pickerStyle(.menu)
+        .labelsHidden()
+      }
+      HStack {
+        Text("minimumActivationDistance")
+        Spacer()
+        Text("\(Int(config.minimumActivationDistance))pt")
+          .frame(width: 36, alignment: .trailing)
+          .foregroundStyle(.secondary)
+        Stepper(
+          "",
+          value: $config.minimumActivationDistance,
+          in: 0...40,
+          step: 5
+        )
         .labelsHidden()
       }
     }

--- a/Development/Development/UIKitDragDemo.swift
+++ b/Development/Development/UIKitDragDemo.swift
@@ -88,12 +88,16 @@ final class UIKitDiagnosticViewController: UIViewController {
     ignoresScrollView: Bool,
     targetEdges: ScrollViewEdge,
     sticksToEdges: Bool,
+    edgeActivationMode: EdgeActivationMode,
+    minimumActivationDistance: CGFloat,
     isScrollLockEnabled: Bool
   ) {
     gesture.configuration = .init(
       ignoresScrollView: ignoresScrollView,
       targetEdges: targetEdges,
-      sticksToEdges: sticksToEdges
+      sticksToEdges: sticksToEdges,
+      edgeActivationMode: edgeActivationMode,
+      minimumActivationDistance: minimumActivationDistance
     )
     gesture.isScrollLockEnabled = isScrollLockEnabled
   }
@@ -163,6 +167,8 @@ struct UIKitDiagnosticHostingView: UIViewControllerRepresentable {
       ignoresScrollView: config.ignoresScrollView,
       targetEdges: config.targetEdges,
       sticksToEdges: config.sticksToEdges,
+      edgeActivationMode: config.edgeActivationMode,
+      minimumActivationDistance: config.minimumActivationDistance,
       isScrollLockEnabled: config.isScrollLockEnabled
     )
   }

--- a/Sources/SwiftUIScrollViewInteroperableDragGesture/DragGestureHandler.swift
+++ b/Sources/SwiftUIScrollViewInteroperableDragGesture/DragGestureHandler.swift
@@ -13,20 +13,40 @@ public struct ScrollViewInteroperableDragGestureValue: Equatable, Sendable {
   }
 }
 
+public enum EdgeActivationMode: Sendable {
+  /// Activate the external handler whenever the scroll view reaches a target edge during the gesture.
+  case anytime
+  /// Activate only if the scroll view was already at the target edge when the gesture began.
+  /// If the gesture started mid-content, the external handler will not fire for this session,
+  /// even if the scroll view reaches an edge mid-drag.
+  case onlyAtGestureStart
+}
+
 public struct ScrollViewInteroperableDragGestureConfiguration: Sendable {
 
   public var targetEdges: ScrollViewEdge
   public var ignoresScrollView: Bool
   public var sticksToEdges: Bool
+  public var edgeActivationMode: EdgeActivationMode
+  /// Minimum distance (in points) the finger must travel from its touch-down
+  /// location before the gesture starts forwarding motion. `0` disables the
+  /// gate (default) and matches the underlying UIPanGestureRecognizer's own
+  /// minimum. Useful to avoid micro-movements momentarily triggering the outer
+  /// drag on light touches.
+  public var minimumActivationDistance: CGFloat
 
   public init(
     ignoresScrollView: Bool,
     targetEdges: ScrollViewEdge,
-    sticksToEdges: Bool
+    sticksToEdges: Bool,
+    edgeActivationMode: EdgeActivationMode = .anytime,
+    minimumActivationDistance: CGFloat = 0
   ) {
     self.ignoresScrollView = ignoresScrollView
     self.sticksToEdges = sticksToEdges
     self.targetEdges = targetEdges
+    self.edgeActivationMode = edgeActivationMode
+    self.minimumActivationDistance = minimumActivationDistance
   }
 }
 
@@ -50,6 +70,17 @@ final class DragGestureHandler {
     var currentScrollController: ScrollController?
     var translation: CGSize = .zero
     var stickingEdges: ScrollViewEdge = []
+    /// Scrollable edges captured on the first frame of the gesture.
+    /// `nil` until a frame with a tracking scroll view is observed.
+    var initialScrollableEdges: ScrollViewEdge? = nil
+    /// Captured once per gesture so we can restore the scroll view's indicator
+    /// visibility after locking hides it.
+    var initialShowsVerticalScrollIndicator: Bool? = nil
+    var initialShowsHorizontalScrollIndicator: Bool? = nil
+    /// Raw accumulated pan translation used only until
+    /// `minimumActivationDistance` is crossed. Discarded afterwards.
+    var preActivationTranslation: CGSize = .zero
+    var hasPassedActivationThreshold: Bool = false
   }
 
   var tracking: Tracking = .init()
@@ -116,6 +147,34 @@ final class DragGestureHandler {
 
       let (panDirection, diff) = recognizer.consumePan()
 
+      // Capture initial scroll-view state on the first frame that sees a
+      // scroll view, BEFORE any activation-distance gating. We want the
+      // snapshot to reflect touches-began state, not post-wobble state.
+      if let scrollView = recognizer.trackingScrollView, tracking.initialScrollableEdges == nil {
+        tracking.initialScrollableEdges = scrollView.scrollableEdges
+        tracking.initialShowsVerticalScrollIndicator = scrollView.showsVerticalScrollIndicator
+        tracking.initialShowsHorizontalScrollIndicator = scrollView.showsHorizontalScrollIndicator
+      }
+
+      // Activation-distance gate: discard the first few points of motion so
+      // micro-movements on a light touch don't flicker the outer drag. A
+      // consumer-imposed `isScrollLockEnabled` bypasses the gate since it
+      // signals an explicit request to own the gesture immediately.
+      if configuration.minimumActivationDistance > 0,
+         tracking.hasPassedActivationThreshold == false,
+         isScrollLockEnabled == false {
+        tracking.preActivationTranslation.width += diff.x
+        tracking.preActivationTranslation.height += diff.y
+        let magnitude = hypot(
+          tracking.preActivationTranslation.width,
+          tracking.preActivationTranslation.height
+        )
+        if magnitude < configuration.minimumActivationDistance {
+          return
+        }
+        tracking.hasPassedActivationThreshold = true
+      }
+
       if let scrollView = recognizer.trackingScrollView {
 
         let scrollController = ScrollController(scrollView: scrollView)
@@ -124,8 +183,13 @@ final class DragGestureHandler {
 
         let scrollableEdges = scrollView.scrollableEdges
 
+        let restoredVerticalIndicator = tracking.initialShowsVerticalScrollIndicator ?? scrollView.showsVerticalScrollIndicator
+        let restoredHorizontalIndicator = tracking.initialShowsHorizontalScrollIndicator ?? scrollView.showsHorizontalScrollIndicator
+
         if isScrollLockEnabled {
           scrollController.lockScrolling(direction: [.horizontal, .vertical])
+          scrollView.showsVerticalScrollIndicator = false
+          scrollView.showsHorizontalScrollIndicator = false
 
           tracking.translation.width += diff.x
           tracking.translation.height += diff.y
@@ -135,14 +199,24 @@ final class DragGestureHandler {
           return
         }
 
+        func allowsPrimary(oppositeEdge: ScrollViewEdge) -> Bool {
+          switch configuration.edgeActivationMode {
+          case .anytime:
+            return true
+          case .onlyAtGestureStart:
+            return tracking.initialScrollableEdges?.contains(oppositeEdge) == false
+          }
+        }
+
         // handling scrolling in scrollview
         if panDirection.contains(.up) {
 
-          if (configuration.targetEdges.contains(.bottom) && scrollableEdges.contains(.bottom) == false)
+          if (configuration.targetEdges.contains(.bottom) && scrollableEdges.contains(.bottom) == false && allowsPrimary(oppositeEdge: .bottom))
             || (configuration.sticksToEdges && tracking.stickingEdges.contains(.top))
           {
 
             scrollController.lockScrolling(direction: .vertical)
+            scrollView.showsVerticalScrollIndicator = false
 
             if configuration.sticksToEdges && tracking.stickingEdges.contains(.top) == false {
               scrollController.scrollTo(edge: .bottom)
@@ -156,6 +230,7 @@ final class DragGestureHandler {
           } else {
 
             scrollController.unlockScrolling(direction: .vertical)
+            scrollView.showsVerticalScrollIndicator = restoredVerticalIndicator
             tracking.isDraggingY = false
 
           }
@@ -164,11 +239,12 @@ final class DragGestureHandler {
 
         if panDirection.contains(.down) {
 
-          if (configuration.targetEdges.contains(.top) && scrollableEdges.contains(.top) == false)
+          if (configuration.targetEdges.contains(.top) && scrollableEdges.contains(.top) == false && allowsPrimary(oppositeEdge: .top))
             || (configuration.sticksToEdges && tracking.stickingEdges.contains(.bottom))
           {
 
             scrollController.lockScrolling(direction: .vertical)
+            scrollView.showsVerticalScrollIndicator = false
 
             if configuration.sticksToEdges && tracking.stickingEdges.contains(.bottom) == false {
               scrollController.scrollTo(edge: .top)
@@ -182,17 +258,19 @@ final class DragGestureHandler {
 
           } else {
             scrollController.unlockScrolling(direction: .vertical)
+            scrollView.showsVerticalScrollIndicator = restoredVerticalIndicator
             tracking.isDraggingY = false
           }
         }
 
         if panDirection.contains(.left) {
 
-          if (configuration.targetEdges.contains(.right) && scrollableEdges.contains(.right) == false)
+          if (configuration.targetEdges.contains(.right) && scrollableEdges.contains(.right) == false && allowsPrimary(oppositeEdge: .right))
             || (configuration.sticksToEdges && tracking.stickingEdges.contains(.left))
           {
 
             scrollController.lockScrolling(direction: .horizontal)
+            scrollView.showsHorizontalScrollIndicator = false
 
             if configuration.sticksToEdges && tracking.stickingEdges.contains(.left) == false {
               scrollController.scrollTo(edge: .right)
@@ -206,6 +284,7 @@ final class DragGestureHandler {
 
           } else {
             scrollController.unlockScrolling(direction: .horizontal)
+            scrollView.showsHorizontalScrollIndicator = restoredHorizontalIndicator
             tracking.isDraggingX = false
 
           }
@@ -214,11 +293,12 @@ final class DragGestureHandler {
 
         if panDirection.contains(.right) {
 
-          if (configuration.targetEdges.contains(.left) && scrollableEdges.contains(.left) == false)
+          if (configuration.targetEdges.contains(.left) && scrollableEdges.contains(.left) == false && allowsPrimary(oppositeEdge: .left))
             || (configuration.sticksToEdges && tracking.stickingEdges.contains(.right))
           {
 
             scrollController.lockScrolling(direction: .horizontal)
+            scrollView.showsHorizontalScrollIndicator = false
 
             if configuration.sticksToEdges && tracking.stickingEdges.contains(.right) == false {
               scrollController.scrollTo(edge: .left)
@@ -232,6 +312,7 @@ final class DragGestureHandler {
 
           } else {
             scrollController.unlockScrolling(direction: .horizontal)
+            scrollView.showsHorizontalScrollIndicator = restoredHorizontalIndicator
             tracking.isDraggingX = false
 
           }
@@ -249,6 +330,18 @@ final class DragGestureHandler {
       }
 
     case .ended, .cancelled, .failed:
+
+      // Restore scroll indicators to whatever state they had when the gesture
+      // began. Safe to run even if no indicator was ever hidden, since setting
+      // a bool property to its existing value is a no-op.
+      if let scrollView = tracking.currentScrollController?.scrollView {
+        if let v = tracking.initialShowsVerticalScrollIndicator {
+          scrollView.showsVerticalScrollIndicator = v
+        }
+        if let h = tracking.initialShowsHorizontalScrollIndicator {
+          scrollView.showsHorizontalScrollIndicator = h
+        }
+      }
 
       var value = Value(
         translation: tracking.translation,

--- a/Sources/SwiftUIScrollViewInteroperableDragGesture/ScrollController.swift
+++ b/Sources/SwiftUIScrollViewInteroperableDragGesture/ScrollController.swift
@@ -90,8 +90,22 @@ final class ScrollController {
   }
 
   func endTracking() {
+    let wasLocked = lockingDirection.isEmpty == false
     unlockScrolling(direction: [.vertical, .horizontal])
     scrollObserver.invalidate()
+
+    if wasLocked {
+      // After the inner scroll view's pan ends, UIKit may schedule a
+      // deceleration animation on the next runloop tick. If we were locked at
+      // release time, the outer gesture "owned" the motion and any residual
+      // scroll decel would visibly fight its follow-through animation. Defer
+      // the cancel to after the current tick so UIKit has already scheduled
+      // the decel we need to override.
+      let scrollView = self.scrollView
+      DispatchQueue.main.async {
+        scrollView.setContentOffset(scrollView.contentOffset, animated: false)
+      }
+    }
   }
 
   func scrollTo(edge: Edge) {
@@ -116,7 +130,10 @@ final class ScrollController {
     defer {
       lockingDirection = previous
     }
-    scrollView.contentOffset = offset
+    // `setContentOffset(_:animated:false)` cancels any in-flight deceleration
+    // animation; direct assignment does not. This matters when locking arrives
+    // while UIScrollView is decelerating from a prior fling.
+    scrollView.setContentOffset(offset, animated: false)
     if previous.isEmpty == false {
       lockedContentOffset = offset
     }

--- a/Tests/SwiftUIScrollViewInteroperableDragGesture/Tests.swift
+++ b/Tests/SwiftUIScrollViewInteroperableDragGesture/Tests.swift
@@ -326,5 +326,335 @@ struct DragGestureHandlerTests {
     #expect(value.velocity.width == 0)  // X axis not dragged, velocity zeroed
     #expect(value.velocity.height == -300)
   }
+
+  // MARK: - edgeActivationMode = .onlyAtGestureStart
+
+  private static let onlyAtStartConfig = ScrollViewInteroperableDragGestureConfiguration(
+    ignoresScrollView: false,
+    targetEdges: .all,
+    sticksToEdges: true,
+    edgeActivationMode: .onlyAtGestureStart
+  )
+
+  @Test("onlyAtGestureStart: mid-content start stays internal even after reaching bottom")
+  func onlyAtStart_midContentStart_doesNotActivate_evenAtEdge() {
+    let scrollView = makeScrollView(contentSize: .init(width: 100, height: 300))
+    scrollView.contentOffset = .init(x: 0, y: 50)  // mid-scroll, bottom still scrollable
+
+    let handler = DragGestureHandler(configuration: Self.onlyAtStartConfig)
+    let recognizer = MockRecognizer()
+    recognizer.trackingScrollView = scrollView
+
+    // Frame 1: mid-content, drag up — should not activate
+    let changes1 = runChanged(handler: handler, recognizer: recognizer, direction: .up, diff: .init(x: 0, y: -10))
+    #expect(changes1.isEmpty)
+    #expect(handler.tracking.stickingEdges.isEmpty)
+
+    // Simulate the scroll view reaching the bottom mid-gesture
+    scrollView.contentOffset = .init(x: 0, y: 200)
+
+    // Frame 2: still dragging up, scroll view is now at bottom — must NOT activate
+    let changes2 = runChanged(handler: handler, recognizer: recognizer, direction: .up, diff: .init(x: 0, y: -10))
+    #expect(changes2.isEmpty)
+    #expect(handler.tracking.stickingEdges.isEmpty)
+    #expect(handler.tracking.translation == .zero)
+    #expect(handler.tracking.isDraggingY == false)
+  }
+
+  @Test("onlyAtGestureStart: start at bottom edge still activates outer on .up")
+  func onlyAtStart_startAtBottom_dragUp_activatesOuter() {
+    let scrollView = makeScrollView(contentSize: .init(width: 100, height: 300))
+    scrollView.contentOffset = .init(x: 0, y: 200)  // at bottom
+
+    let handler = DragGestureHandler(configuration: Self.onlyAtStartConfig)
+    let recognizer = MockRecognizer()
+    recognizer.trackingScrollView = scrollView
+
+    let changes = runChanged(handler: handler, recognizer: recognizer, direction: .up, diff: .init(x: 0, y: -10))
+
+    #expect(changes.count == 1)
+    #expect(handler.tracking.stickingEdges == [.bottom])
+    #expect(handler.tracking.translation == .init(width: 0, height: -10))
+  }
+
+  @Test("onlyAtGestureStart: sticky reversal still works once activated")
+  func onlyAtStart_stickyReversal_afterActivation() {
+    let scrollView = makeScrollView(contentSize: .init(width: 100, height: 300))
+    scrollView.contentOffset = .init(x: 0, y: 200)  // at bottom
+
+    let handler = DragGestureHandler(configuration: Self.onlyAtStartConfig)
+    let recognizer = MockRecognizer()
+    recognizer.trackingScrollView = scrollView
+
+    _ = runChanged(handler: handler, recognizer: recognizer, direction: .up, diff: .init(x: 0, y: -10))
+    #expect(handler.tracking.stickingEdges == [.bottom])
+
+    let changes = runChanged(handler: handler, recognizer: recognizer, direction: .down, diff: .init(x: 0, y: 5))
+
+    #expect(handler.tracking.stickingEdges == [.bottom, .top])
+    #expect(handler.tracking.translation == .init(width: 0, height: -5))
+    #expect(changes.count == 1)
+  }
+
+  @Test("onlyAtGestureStart: initial edges are reset per gesture via purge")
+  func onlyAtStart_perGestureSnapshotReset() {
+    let scrollView = makeScrollView(contentSize: .init(width: 100, height: 300))
+    scrollView.contentOffset = .init(x: 0, y: 50)  // mid-content
+
+    let handler = DragGestureHandler(configuration: Self.onlyAtStartConfig)
+    let recognizer = MockRecognizer()
+    recognizer.trackingScrollView = scrollView
+
+    // Gesture 1: mid-content start, should not activate
+    _ = runChanged(handler: handler, recognizer: recognizer, direction: .up, diff: .init(x: 0, y: -10))
+    #expect(handler.tracking.stickingEdges.isEmpty)
+
+    // End the gesture → purge
+    recognizer.state = .ended
+    recognizer.pan = ([], .zero)
+    handler.handle(
+      recognizer: recognizer,
+      location: { .zero },
+      velocity: { nil },
+      onChange: { _ in },
+      onEnd: { _ in }
+    )
+    #expect(handler.tracking.initialScrollableEdges == nil)
+
+    // Gesture 2: now at bottom, should activate
+    scrollView.contentOffset = .init(x: 0, y: 200)
+    let changes = runChanged(handler: handler, recognizer: recognizer, direction: .up, diff: .init(x: 0, y: -10))
+    #expect(changes.count == 1)
+    #expect(handler.tracking.stickingEdges == [.bottom])
+  }
+
+  @Test("onlyAtGestureStart: horizontal — start at right edge activates .left")
+  func onlyAtStart_horizontal_startAtRight_dragLeft_activates() {
+    let scrollView = makeScrollView(contentSize: .init(width: 300, height: 100))
+    scrollView.contentOffset = .init(x: 200, y: 0)  // at right edge
+
+    let handler = DragGestureHandler(configuration: Self.onlyAtStartConfig)
+    let recognizer = MockRecognizer()
+    recognizer.trackingScrollView = scrollView
+
+    let changes = runChanged(handler: handler, recognizer: recognizer, direction: .left, diff: .init(x: -10, y: 0))
+
+    #expect(changes.count == 1)
+    #expect(handler.tracking.stickingEdges == [.right])
+  }
+
+  @Test("onlyAtGestureStart: horizontal — start at left edge activates .right")
+  func onlyAtStart_horizontal_startAtLeft_dragRight_activates() {
+    let scrollView = makeScrollView(contentSize: .init(width: 300, height: 100))
+    scrollView.contentOffset = .zero  // at left edge
+
+    let handler = DragGestureHandler(configuration: Self.onlyAtStartConfig)
+    let recognizer = MockRecognizer()
+    recognizer.trackingScrollView = scrollView
+
+    let changes = runChanged(handler: handler, recognizer: recognizer, direction: .right, diff: .init(x: 10, y: 0))
+
+    #expect(changes.count == 1)
+    #expect(handler.tracking.stickingEdges == [.left])
+  }
+
+  @Test("onlyAtGestureStart: horizontal — mid-content .right drag does not activate even at left")
+  func onlyAtStart_horizontal_midContent_dragRight_doesNotActivate() {
+    let scrollView = makeScrollView(contentSize: .init(width: 300, height: 100))
+    scrollView.contentOffset = .init(x: 50, y: 0)  // mid-content horizontally
+
+    let handler = DragGestureHandler(configuration: Self.onlyAtStartConfig)
+    let recognizer = MockRecognizer()
+    recognizer.trackingScrollView = scrollView
+
+    _ = runChanged(handler: handler, recognizer: recognizer, direction: .right, diff: .init(x: 10, y: 0))
+
+    // Simulate reaching the left edge mid-gesture
+    scrollView.contentOffset = .init(x: 0, y: 0)
+    let changes = runChanged(handler: handler, recognizer: recognizer, direction: .right, diff: .init(x: 10, y: 0))
+
+    #expect(changes.isEmpty)
+    #expect(handler.tracking.stickingEdges.isEmpty)
+  }
+
+  // MARK: - minimumActivationDistance
+
+  private static let thresholdConfig = ScrollViewInteroperableDragGestureConfiguration(
+    ignoresScrollView: false,
+    targetEdges: .all,
+    sticksToEdges: true,
+    minimumActivationDistance: 10
+  )
+
+  @Test("minimumActivationDistance: below threshold, no onChange even at edge")
+  func threshold_belowThreshold_doesNotActivate() {
+    let scrollView = makeScrollView(contentSize: .init(width: 100, height: 300))
+    scrollView.contentOffset = .init(x: 0, y: 200)  // at bottom
+
+    let handler = DragGestureHandler(configuration: Self.thresholdConfig)
+    let recognizer = MockRecognizer()
+    recognizer.trackingScrollView = scrollView
+
+    // 4 + 4 = 8pt total — below 10pt threshold
+    let changes1 = runChanged(handler: handler, recognizer: recognizer, direction: .up, diff: .init(x: 0, y: -4))
+    let changes2 = runChanged(handler: handler, recognizer: recognizer, direction: .up, diff: .init(x: 0, y: -4))
+
+    #expect(changes1.isEmpty)
+    #expect(changes2.isEmpty)
+    #expect(handler.tracking.stickingEdges.isEmpty)
+    #expect(handler.tracking.hasPassedActivationThreshold == false)
+  }
+
+  @Test("minimumActivationDistance: crossing threshold enables processing")
+  func threshold_crossingThreshold_activates() {
+    let scrollView = makeScrollView(contentSize: .init(width: 100, height: 300))
+    scrollView.contentOffset = .init(x: 0, y: 200)
+
+    let handler = DragGestureHandler(configuration: Self.thresholdConfig)
+    let recognizer = MockRecognizer()
+    recognizer.trackingScrollView = scrollView
+
+    // 4pt — under
+    _ = runChanged(handler: handler, recognizer: recognizer, direction: .up, diff: .init(x: 0, y: -4))
+    #expect(handler.tracking.hasPassedActivationThreshold == false)
+
+    // accumulated 16pt — over 10pt
+    let changes = runChanged(handler: handler, recognizer: recognizer, direction: .up, diff: .init(x: 0, y: -12))
+    #expect(handler.tracking.hasPassedActivationThreshold == true)
+    // The crossing-frame's diff is processed normally, so the outer onChange fires.
+    #expect(changes.count == 1)
+    #expect(handler.tracking.stickingEdges == [.bottom])
+  }
+
+  @Test("minimumActivationDistance: measured as magnitude from start, not path length")
+  func threshold_jiggleDoesNotAccumulate() {
+    let scrollView = makeScrollView(contentSize: .init(width: 100, height: 300))
+    scrollView.contentOffset = .init(x: 0, y: 200)
+
+    let handler = DragGestureHandler(configuration: Self.thresholdConfig)
+    let recognizer = MockRecognizer()
+    recognizer.trackingScrollView = scrollView
+
+    // Jiggle: +6 -6 +6 -6 = net 0, path length 24 — should NOT cross 10pt threshold
+    _ = runChanged(handler: handler, recognizer: recognizer, direction: .up, diff: .init(x: 0, y: -6))
+    _ = runChanged(handler: handler, recognizer: recognizer, direction: .down, diff: .init(x: 0, y: 6))
+    _ = runChanged(handler: handler, recognizer: recognizer, direction: .up, diff: .init(x: 0, y: -6))
+    let changes = runChanged(handler: handler, recognizer: recognizer, direction: .down, diff: .init(x: 0, y: 6))
+
+    #expect(handler.tracking.hasPassedActivationThreshold == false)
+    #expect(changes.isEmpty)
+  }
+
+  @Test("minimumActivationDistance: isScrollLockEnabled bypasses the gate")
+  func threshold_isScrollLockEnabledBypasses() {
+    let scrollView = makeScrollView(contentSize: .init(width: 100, height: 300))
+    scrollView.contentOffset = .init(x: 0, y: 50)
+
+    let handler = DragGestureHandler(configuration: Self.thresholdConfig)
+    handler.isScrollLockEnabled = true
+    let recognizer = MockRecognizer()
+    recognizer.trackingScrollView = scrollView
+
+    let changes = runChanged(handler: handler, recognizer: recognizer, direction: .up, diff: .init(x: 0, y: -4))
+
+    #expect(changes.count == 1)
+    #expect(handler.tracking.translation == .init(width: 0, height: -4))
+  }
+
+  // MARK: - Scroll indicator hide/restore
+
+  @Test("Scroll indicator is hidden on lock, restored on .ended")
+  func indicator_hiddenOnLock_restoredOnEnded() {
+    let scrollView = makeScrollView(contentSize: .init(width: 100, height: 300))
+    scrollView.contentOffset = .init(x: 0, y: 200)
+    scrollView.showsVerticalScrollIndicator = true
+
+    let handler = DragGestureHandler(configuration: defaultConfig)
+    let recognizer = MockRecognizer()
+    recognizer.trackingScrollView = scrollView
+
+    _ = runChanged(handler: handler, recognizer: recognizer, direction: .up, diff: .init(x: 0, y: -10))
+    #expect(scrollView.showsVerticalScrollIndicator == false)
+
+    // End gesture — indicator restored to initial value
+    recognizer.state = .ended
+    recognizer.pan = ([], .zero)
+    handler.handle(
+      recognizer: recognizer,
+      location: { .zero },
+      velocity: { nil },
+      onChange: { _ in },
+      onEnd: { _ in }
+    )
+
+    #expect(scrollView.showsVerticalScrollIndicator == true)
+  }
+
+  @Test("Scroll indicator restored to initial false value")
+  func indicator_initiallyHidden_stillRestoredAfterGesture() {
+    let scrollView = makeScrollView(contentSize: .init(width: 100, height: 300))
+    scrollView.contentOffset = .init(x: 0, y: 200)
+    scrollView.showsVerticalScrollIndicator = false  // consumer-hidden
+
+    let handler = DragGestureHandler(configuration: defaultConfig)
+    let recognizer = MockRecognizer()
+    recognizer.trackingScrollView = scrollView
+
+    _ = runChanged(handler: handler, recognizer: recognizer, direction: .up, diff: .init(x: 0, y: -10))
+    #expect(scrollView.showsVerticalScrollIndicator == false)
+
+    recognizer.state = .ended
+    recognizer.pan = ([], .zero)
+    handler.handle(
+      recognizer: recognizer,
+      location: { .zero },
+      velocity: { nil },
+      onChange: { _ in },
+      onEnd: { _ in }
+    )
+
+    // Remains false (initial was false)
+    #expect(scrollView.showsVerticalScrollIndicator == false)
+  }
+
+  @Test("Unlocking mid-gesture restores indicator immediately")
+  func indicator_restoredOnUnlock() {
+    let scrollView = makeScrollView(contentSize: .init(width: 100, height: 300))
+    scrollView.contentOffset = .init(x: 0, y: 200)  // at bottom
+    scrollView.showsVerticalScrollIndicator = true
+
+    let handler = DragGestureHandler(configuration: .init(
+      ignoresScrollView: false,
+      targetEdges: .all,
+      sticksToEdges: false
+    ))
+    let recognizer = MockRecognizer()
+    recognizer.trackingScrollView = scrollView
+
+    // Frame 1: activate (at bottom, drag up) — indicator hidden
+    _ = runChanged(handler: handler, recognizer: recognizer, direction: .up, diff: .init(x: 0, y: -10))
+    #expect(scrollView.showsVerticalScrollIndicator == false)
+
+    // Frame 2: reverse (drag down) — without sticky, unlocks, indicator restored
+    _ = runChanged(handler: handler, recognizer: recognizer, direction: .down, diff: .init(x: 0, y: 10))
+    #expect(scrollView.showsVerticalScrollIndicator == true)
+  }
+
+  @Test("Horizontal indicator is managed independently of vertical")
+  func indicator_horizontalVsVertical_independent() {
+    let scrollView = makeScrollView(contentSize: .init(width: 300, height: 300))
+    scrollView.contentOffset = .init(x: 200, y: 50)  // at right, mid-scroll vertically
+    scrollView.showsVerticalScrollIndicator = true
+    scrollView.showsHorizontalScrollIndicator = true
+
+    let handler = DragGestureHandler(configuration: defaultConfig)
+    let recognizer = MockRecognizer()
+    recognizer.trackingScrollView = scrollView
+
+    // Drag left (at right edge) — horizontal locks, vertical unaffected
+    _ = runChanged(handler: handler, recognizer: recognizer, direction: .left, diff: .init(x: -10, y: 0))
+    #expect(scrollView.showsHorizontalScrollIndicator == false)
+    #expect(scrollView.showsVerticalScrollIndicator == true)
+  }
 }
 #endif


### PR DESCRIPTION
## Summary

Adds four gesture-coordination refinements to `ScrollViewInteroperableDragGesture`, driven by two independent needs:

1. **`edgeActivationMode` enum** — Restores a behavior that existed inline in v0.2.0 and was dropped during the `DragGestureHandler` refactor. swiftui-blanket pins v0.2.0 for exactly this reason.
2. **Three Rideau-inspired hardening touches** — on request after comparing this library against Rideau's scroll-view coordination.

All additions are source-compatible; defaults preserve the existing behavior.

## What changes

### 1. `EdgeActivationMode` configuration
```swift
public enum EdgeActivationMode: Sendable {
  case anytime            // current behavior
  case onlyAtGestureStart // only activate outer if scroll view was already at a target edge on touches-began
}
```
In `.onlyAtGestureStart` mode, a gesture that starts with the scroll view mid-content stays internal for the whole session even if the user scrolls all the way to the edge. The `initialScrollableEdges` snapshot is captured once per gesture and cleared by `purgeTrackingState()`.

### 2. `minimumActivationDistance: CGFloat`
Discards pan motion until the finger has traveled the configured distance from touch-down, measured as **vector magnitude** (`hypot`) so a jiggle does not accumulate toward the threshold. Rideau uses a fixed 15pt gate for the same reason. Default `0` preserves current behavior; `isScrollLockEnabled` bypasses the gate since it is an explicit consumer request to own the gesture immediately.

### 3. Scroll indicator hide-on-lock / restore
The inner `UIScrollView`'s `showsVerticalScrollIndicator` / `showsHorizontalScrollIndicator` are hidden while that axis is locked and restored when it unlocks (or on `.ended/.cancelled/.failed`). The pre-gesture value is captured once per gesture and restored on end, so a scroll view that started with a hidden indicator stays hidden.

### 4. `ScrollController`: cancel / defer-cancel deceleration
- `setContentOffset(_:)` now uses `scrollView.setContentOffset(offset, animated: false)` instead of direct assignment so locking cancels any in-flight UIScrollView deceleration.
- `endTracking()` — if the controller was still locked at release — schedules a deferred `setContentOffset(sv.contentOffset, animated: false)` on the main queue so UIKit's post-release decel (scheduled after our callback returns) is overridden and does not fight the outer gesture's follow-through animation. Matches Rideau's `Kill scroll deceleration` pattern.

### 5. Development app
`ConfigPanel` gains `edgeActivationMode` (picker) and `minimumActivationDistance` (stepper, 0–40pt). Both demos (SwiftUI and UIKit) propagate them.

## Test plan

- [x] Existing 12 tests still pass (no regression in `.anytime` default).
- [x] 8 new tests for `.onlyAtGestureStart` covering mid-content vs edge start, sticky reversal, per-gesture snapshot reset, horizontal parity (incl. `.right`-branch typo guard against the v0.2.0 regression).
- [x] 4 new tests for `minimumActivationDistance`: below threshold, crossing, jiggle (path-length > threshold but displacement < threshold stays idle), `isScrollLockEnabled` bypass.
- [x] 4 new tests for indicator management: hide on lock + restore on end, initially-hidden stays hidden, mid-gesture unlock restores immediately, horizontal/vertical independent.
- [x] `xcodebuild test` on iOS 26.4 Simulator: 28/28 pass.
- [x] `Development` app builds for iOS Simulator.
- [ ] Manual check in swiftui-blanket by bumping this dep and setting `edgeActivationMode: .onlyAtGestureStart` in its gesture config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)